### PR TITLE
Fix: String comparisons, formatting, path_prefix handling

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -3,37 +3,56 @@
 # SPDX-FileCopyrightText: 2025 The Linux Foundation
 
 # Action test/validation workflow
-name: "Test GitHub Action 🧪"
+name: 'Test GitHub Action 🧪'
 
 # yamllint disable-line rule:truthy
 on:
   workflow_dispatch:
   push:
-    branches: ["main"]
+    branches: ['main']
   pull_request:
-    branches: ["main"]
+    branches: ['main']
+
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: true
 
 permissions: {}
 
 jobs:
   ### Test the GitHub Action in this Repository ###
   tests:
-    name: "Action Testing"
-    runs-on: ubuntu-24.04
+    name: 'Action Testing'
+    runs-on: 'ubuntu-24.04'
     permissions:
       contents: read
     steps:
-      - name: "Checkout repository"
+      - name: 'Checkout repository'
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       # Perform setup prior to running test(s)
-      - name: "Checkout sample project repository"
+      - name: 'Checkout sample project repository'
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          repository: "lfreleng-actions/test-python-project"
-          path: "test-python-project"
+          repository: 'lfreleng-actions/test-python-project'
+          path: 'test-python-project'
 
       - name: "Run Action: ${{ github.repository }}"
         uses: ./
+        id: test
         with:
-          path_prefix: "test-python-project/"
+          path_prefix: 'test-python-project'
+
+      - name: "Validate action output: ${{ github.repository }}"
+        shell: bash
+        run: |
+          # Validate Action Output
+          if [ "${{ steps.test.outputs.python_project_version }}" \
+            = '0.0.1' ]; then
+            echo "Action returned the expected results ✅"
+          else
+            echo 'Unexpected return value for: python_project_version ❌'
+            echo "Returned: ${{ steps.test.outputs.python_project_version }}"
+            echo 'Expected: 0.0.1'
+            exit 1
+          fi

--- a/README.md
+++ b/README.md
@@ -16,15 +16,19 @@ An example workflow step using this action:
 
 ```yaml
   # Code checkout performed in earlier workflow step
-  - name: Retrieve the current Python Project version
+  - name: 'Retrieve the current Python project version'
     uses: lfreleng-actions/python-project-version-action@main
 ```
 
 ## Inputs
 
-| Output Variable     | Description                                    |
-| ------------------- | ---------------------------------------------- |
-| PATH_PREFIX         | Directory path to the repository/project files |
+<!-- markdownlint-disable MD013 -->
+
+| Output Variable     | Required | Description                                    |
+| ------------------- | -------- | ---------------------------------------------- |
+| path_prefix         | False    | Directory path to the repository/project files |
+
+<!-- markdownlint-enable MD013 -->
 
 ## Outputs
 
@@ -32,7 +36,9 @@ An example workflow step using this action:
 
 | Output Variable        | Description                                                   |
 | ---------------------- | ------------------------------------------------------------- |
-| PYTHON_PROJECT_VERSION | Current version of the Python Project                         |
-| SOURCE                 | Project metadata/description file [ pyproject.toml/setup.py ] |
+| python_project_version | Current version of the Python Project                         |
+| source                 | Project metadata/description file [ pyproject.toml/setup.py ] |
+
+Note: python_project_version set to 'dynamic' when dynamic project versioning enabled
 
 <!-- markdownlint-enable MD013 -->

--- a/action.yaml
+++ b/action.yaml
@@ -3,117 +3,115 @@
 # SPDX-FileCopyrightText: 2025 The Linux Foundation
 
 # python-project-version-action
-name: "🐍 Python Project Current Version"
-description: "Returns the current version of a Python Project"
+name: '🐍 Python Project Version'
+description: 'Returns the version of a Python Project'
 # Supports both pyproject.toml and setup.py project descriptions
 
 inputs:
-  # Mandatory
-  PATH_PREFIX:
-    description: "Directory location containing project code"
+  # Optional
+  path_prefix:
+    description: 'Directory location containing project code'
     type: string
     required: false
+    default: '.'
 
 outputs:
-  PYTHON_PROJECT_VERSION:
-    description: "The current version declared for a Python project"
-    value: ${{ steps.publish.outputs.python_project_version }}
-  SOURCE:
+  python_project_version:
+    description: 'The current version declared for a Python project'
+    value: "${{ steps.set.outputs.python_project_version }}"
+  source:
     # yamllint disable-line rule:line-length
-    description: "File used to source project metadata [pyproject.toml|setup.py]"
-    value: ${{ steps.publish.outputs.python_project_version }}
+    description: 'File used to source project metadata [pyproject.toml|setup.py]'
+    value: "${{ steps.set.outputs.python_project_version }}"
 
 runs:
-  using: "composite"
+  using: 'composite'
   steps:
-    - name: "Setup action/environment"
+    - name: 'Setup action/environment'
       shell: bash
       run: |
         # Setup action/environment
-        # Handle path_prefix input consistently and when absent
-        path_prefix="${{ inputs.PATH_PREFIX }}"
-        if [ -z "$path_prefix" ]; then
-          # Set current directory as path prefix
-          path_prefix="."
-        else
-          # Strip any trailing slash in provided path
-          path_prefix="${path_prefix%/}"
+
+        # Verify path_prefix a valid directory path
+        if [ ! -d "${{ inputs.path_prefix }}" ]; then
+          echo 'Error: invalid path/prefix to project directory ❌'; exit 1
         fi
-        # Verify is a valid directory path
-        if [ ! -d "$path_prefix" ]; then
-          echo "Error: invalid path/prefix to project directory ❌"; exit 1
-        fi
-        echo "path_prefix=$path_prefix" >> "$GITHUB_ENV"
 
     # yamllint disable-line rule:line-length
     - uses: lfreleng-actions/path-check-action@594fa4a73651e3e869a4829397e878932f7db32c # v0.1.4
-      id: setup-py
+      id: 'setup-py'
       with:
-        path: "${{ env.path_prefix }}/setup-py"
+        path: "${{ inputs.path_prefix }}/setup-py"
 
-    - name: "Use project version from setup.py"
-      id: setup-py-version
+    - name: 'Use project version from setup.py'
+      id: 'setup-py-version'
       if: steps.setup-py.outputs.type == 'file'
       # yamllint disable-line rule:line-length
       uses: lfreleng-actions/file-grep-regex-action@e065e0d8edca06116113b652b077053c1f7056a0 # v0.1.2
       with:
-        flags: "-oP -m1"
+        flags: '-oP -m1'
         # https://regex101.com/r/QKYHId/1
         regex: '(?<=version=")([^"]*)'
-        filename: "${{ env.path_prefix }}/setup.py"
+        filename: "${{ inputs.path_prefix }}/setup.py"
 
     # yamllint disable-line rule:line-length
     - uses: lfreleng-actions/path-check-action@594fa4a73651e3e869a4829397e878932f7db32c # v0.1.4
-      id: pyproject-toml
+      id: 'pyproject-toml'
       with:
-        path: "${{ env.path_prefix }}/pyproject.toml"
+        path: "${{ inputs.path_prefix }}/pyproject.toml"
 
-    - name: "Use project version from pyproject.toml"
-      id: pyproject-toml-version
-      if: steps.pyproject-toml.outputs.type == 'file'
-      # yamllint disable-line rule:line-length
-      uses: lfreleng-actions/file-grep-regex-action@e065e0d8edca06116113b652b077053c1f7056a0 # v0.1.2
-      with:
-        flags: "-oP -m1"
-        # https://regex101.com/r/MWmRge/1
-        regex: '(?<=^version = ")([^"]*)'
-        filename: "${{ env.path_prefix }}/pyproject.toml"
-
-    - name: "Error: Python project metadata NOT found"
+    - name: 'Error: Python project metadata NOT found'
       if: steps.pyproject-toml.outputs.type == 'invalid' &&
         steps.setup-py.outputs.type == 'invalid'
       shell: bash
       run: |
         # Error: Python project metadata NOT found
-        echo "Error: neither pyproject.toml nor setup.py were found ❌"
+        echo 'Error: neither pyproject.toml nor setup.py were found ❌'
         exit 1
 
-    - name: "Return extracted values"
-      id: publish
+    - name: 'Determine versioning type [static|dynamic]'
+      if: steps.project-toml.outputs.type == 'file'
+      id: versioning
+      # yamllint disable-line rule:line-length
+      uses: lfreleng-actions/python-dynamic-version-action@f645b6d3c3a64709d598b3cd54d5766a0469fb44 # v0.1.5
+      with:
+        path_prefix: "${{ inputs.path_prefix }}"
+
+    - name: 'Use project version from pyproject.toml'
+      id: 'pyproject-toml-version'
+      # yamllint disable-line rule:line-length
+      if: steps.pyproject-toml.outputs.type == 'file' && steps.versioning.outputs.dynamic_version != 'true'
+      # yamllint disable-line rule:line-length
+      uses: lfreleng-actions/file-grep-regex-action@e065e0d8edca06116113b652b077053c1f7056a0 # v0.1.2
+      with:
+        flags: '-oP -m1'
+        # https://regex101.com/r/MWmRge/1
+        regex: '(?<=^version = ")([^"]*)'
+        filename: "${{ inputs.path_prefix }}/pyproject.toml"
+
+    - name: 'Return extracted values'
+      id: set
       shell: bash
       # yamllint disable rule:line-length
       run: |
         # Return extracted values
 
-        # pyproject.toml is preferred source if both files exist
-        if [ ${{ steps.pyproject-toml.outputs.type == 'file' }} ]; then
-          echo "Using project version from source: pyproject.toml ✅"
-          echo "source=pyproject.toml" >> "$GITHUB_ENV"
-          echo "source=pyproject.toml" >> "$GITHUB_OUTPUT"
-          PYTHON_PROJECT_VERSION="${{ steps.pyproject-toml-version.outputs.extracted_string}}"
-
-        elif [ ${{ steps.setup-py.outputs.type == 'file' }} ]; then
-          echo "Using project version from source: setup.py ⚠️"
-          echo "Warning: consider migrating to modern PEP standards"
-          echo "source=setup.py" >> "$GITHUB_ENV"
-          echo "source=setup.py" >> "$GITHUB_OUTPUT"
-          PYTHON_PROJECT_VERSION="${{ steps.setup-py-version.outputs.extracted_string}}"
+        if [ "${{ steps.pyproject-toml.outputs.type }}" = 'file' ]; then
+          source='pyproject.toml'
+          version="${{ steps.pyproject-toml-version.outputs.extracted_string}}"
+        elif [ "${{ steps.setup-py.outputs.type }}" = 'file' ]; then
+          source='setup.py'
+          version="${{ steps.setup-py-version.outputs.extracted_string}}"
+        fi
+        if [ "${{ steps.versioning.outputs.dynamic_version }}" = 'true' ]; then
+          version='dynamic'
         fi
 
         # Validate and output captured value
-        if [ -z "$PYTHON_PROJECT_VERSION" ]; then
-          echo "The project name extraction failed ❌"; exit 1
+        if [ -z "$version" ]; then
+          echo 'Project version extraction failed ❌'; exit 1
+        else
+          echo "Python project version: $version [$source] ✅"
+          echo "python_project_version=$version" >> "$GITHUB_ENV"
+          echo "python_project_version=$version" >> "$GITHUB_OUTPUT"
         fi
-        echo "python_project_version: $PYTHON_PROJECT_VERSION ✅"
-        echo "python_project_version=$PYTHON_PROJECT_VERSION" >> "$GITHUB_ENV"
-        echo "python_project_version=$PYTHON_PROJECT_VERSION" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
There were some invalid string comparisons that needed addressing. Also addresses variable capitalisation. Setup.py is deprecated as an executable script, but not as a setuptools configuration, so the warning has been removed. Now checks for dynamic versioning when reading the project configuration from pyproject.toml file.