### PR TITLE
Feat: rewrite using Python helper with comprehensive legacy support

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -22,28 +22,37 @@ permissions: {}
 jobs:
   # Pytest-based unit/integration tests covering every supported project
   # layout (modern, legacy, dynamic provider, error path) without
-  # touching the runner's filesystem outside tmp_path.
+  # touching the runner's filesystem outside tmp_path. The matrix
+  # exercises both the native ``tomllib`` path (3.11+) and the
+  # ``tomli`` fallback path (3.10) declared in ``extract_version.py``.
   pytest:
-    name: 'Pytest fixture matrix'
+    name: 'Pytest (py${{ matrix.python-version }})'
     runs-on: 'ubuntu-24.04'
     permissions:
       contents: read
     timeout-minutes: 5
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.10', '3.11']
     steps:
       - name: 'Checkout repository'
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: 'Setup Python'
         # yamllint disable-line rule:line-length
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: '3.11'
+          python-version: ${{ matrix.python-version }}
 
-      - name: 'Install pytest'
+      - name: 'Install pytest (and tomli on 3.10)'
         shell: bash
         run: |
           python -m pip install --upgrade pip
           python -m pip install pytest
+          if [ "${{ matrix.python-version }}" = '3.10' ]; then
+            python -m pip install tomli
+          fi
 
       - name: 'Run extractor test suite'
         shell: bash
@@ -61,10 +70,10 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: 'Checkout repository'
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: 'Checkout sample project repository'
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: 'lfreleng-actions/test-python-project'
           path: 'test-python-project'

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -20,20 +20,51 @@ concurrency:
 permissions: {}
 
 jobs:
-  ### Test the GitHub Action in this Repository ###
-  tests:
-    name: 'Action Testing'
+  # Pytest-based unit/integration tests covering every supported project
+  # layout (modern, legacy, dynamic provider, error path) without
+  # touching the runner's filesystem outside tmp_path.
+  pytest:
+    name: 'Pytest fixture matrix'
     runs-on: 'ubuntu-24.04'
     permissions:
       contents: read
     timeout-minutes: 5
     steps:
       - name: 'Checkout repository'
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      # Perform setup prior to running test(s)
+      - name: 'Setup Python'
+        # yamllint disable-line rule:line-length
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.11'
+
+      - name: 'Install pytest'
+        shell: bash
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pytest
+
+      - name: 'Run extractor test suite'
+        shell: bash
+        run: |
+          python -m pytest tests/test_extract_version.py -v
+
+  # End-to-end smoke test against the real sample project. Confirms the
+  # composite action wraps the helper script correctly and surfaces all
+  # four outputs as documented.
+  smoke:
+    name: 'End-to-end smoke test'
+    runs-on: 'ubuntu-24.04'
+    permissions:
+      contents: read
+    timeout-minutes: 5
+    steps:
+      - name: 'Checkout repository'
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
       - name: 'Checkout sample project repository'
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: 'lfreleng-actions/test-python-project'
           path: 'test-python-project'
@@ -41,13 +72,12 @@ jobs:
       - name: 'Setup static version fixture for testing'
         shell: bash
         run: |
-          # Setup static version fixture for testing
           # test-python-project now uses dynamic versioning;
-          # copy static variation for version extraction test
+          # copy the static variation in for the static-extraction test.
           cp test-python-project/variations/static-eol.toml \
             test-python-project/pyproject.toml
 
-      - name: "Run Action: ${{ github.repository }}"
+      - name: "Run Action: ${{ github.repository }} [static]"
         uses: ./
         id: test
         with:
@@ -59,19 +89,36 @@ jobs:
           # Validate Action Output
           if [ "${{ steps.test.outputs.python_project_version }}" \
             = '0.0.1' ]; then
-            echo "Action returned the expected results ✅"
+            echo "Action returned the expected version ✅"
           else
             echo 'Unexpected return value for: python_project_version ❌'
             echo "Returned: ${{ steps.test.outputs.python_project_version }}"
             echo 'Expected: 0.0.1'
             exit 1
           fi
+          # Source output must be the actual file path now, not the
+          # version string (regression test for the previous copy-paste bug).
+          source='${{ steps.test.outputs.source }}'
+          case "$source" in
+            *pyproject.toml)
+              echo "Source output is correct ($source) ✅"
+              ;;
+            *)
+              echo "Unexpected source output: $source ❌"
+              echo "Expected a path ending in pyproject.toml"
+              exit 1
+              ;;
+          esac
+          # Verify the new outputs are present and have expected values.
+          if [ "${{ steps.test.outputs.dynamic_version }}" != 'false' ]; then
+            echo 'Expected dynamic_version=false for a static-version project ❌'
+            exit 1
+          fi
+          echo 'All outputs validated successfully ✅'
 
-      # Test dynamic versioning detection
       - name: 'Restore dynamic pyproject.toml'
         shell: bash
         run: |
-          # Restore original dynamic pyproject.toml
           git -C test-python-project checkout -- pyproject.toml
 
       - name: "Run Action: ${{ github.repository }} [dynamic]"
@@ -83,13 +130,18 @@ jobs:
       - name: "Validate dynamic version output"
         shell: bash
         run: |
-          # Validate dynamic versioning detection
-          VERSION="${{ steps.test-dynamic.outputs.python_project_version }}"
-          if [ "$VERSION" = 'dynamic' ]; then
-            echo "Dynamic versioning detected correctly ✅"
-          else
-            echo "Unexpected: python_project_version ❌"
-            echo "Returned: $VERSION"
-            echo 'Expected: dynamic'
+          version='${{ steps.test-dynamic.outputs.python_project_version }}'
+          dynamic='${{ steps.test-dynamic.outputs.dynamic_version }}'
+          provider='${{ steps.test-dynamic.outputs.dynamic_provider }}'
+          if [ "$version" != 'dynamic' ] || [ "$dynamic" != 'true' ]; then
+            echo 'Dynamic versioning not detected ❌'
+            echo "version=$version dynamic_version=$dynamic"
             exit 1
           fi
+          if [ -z "$provider" ]; then
+            msg='dynamic_provider must not be empty for'
+            msg="$msg dynamic-versioned projects ❌"
+            echo "$msg"
+            exit 1
+          fi
+          echo "Dynamic versioning detected ($provider) ✅"

--- a/README.md
+++ b/README.md
@@ -5,28 +5,51 @@ SPDX-FileCopyrightText: 2025 The Linux Foundation
 
 # 🐍 Python Project Current Version
 
-Returns the current version of a Python Project declared in the metadata
-description/files. Supports both pyproject.toml and setup.py locations.
+Returns the current version of a Python project, derived from any of the
+supported metadata locations:
 
-## python-project-version-action
+- `pyproject.toml` (PEP 621 `[project].version`, or `[tool.poetry].version`)
+- `setup.cfg` (`[metadata] version`)
+- `setup.py` (regex-based, single- and double-quoted forms)
+
+The action recognises dynamic versioning providers and reports them via
+the `dynamic_provider` output:
+
+- **pbr** — OpenStack / LFIT convention (`pbr = True`, `setup_requires =
+  ['pbr']`, or a `[pbr]` section in `setup.cfg`)
+- **setuptools-scm** — `use_scm_version`, `setup_requires` containing
+  `setuptools_scm`, or `setuptools-scm` listed in `[build-system].requires`
+- **versioneer** — `versioneer.get_version` / `get_cmdclass`
+- **setuptools-dynamic** — `version = attr:` / `version = file:` in
+  `setup.cfg`
+- **hatch-vcs** — `hatch-vcs` listed in `[build-system].requires`
+- **pyproject-dynamic** — `dynamic = ["version"]` declared without a
+  recognised provider
+- **runtime-attr** — `version=__version__` style indirection in `setup.py`
 
 ## Usage Example
-
-An example workflow step using this action:
 
 ```yaml
   # Code checkout performed in earlier workflow step
   - name: 'Retrieve the current Python project version'
+    id: version
     uses: lfreleng-actions/python-project-version-action@main
+
+  - name: 'Print version info'
+    run: |
+      echo "version:  ${{ steps.version.outputs.python_project_version }}"
+      echo "source:   ${{ steps.version.outputs.source }}"
+      echo "dynamic:  ${{ steps.version.outputs.dynamic_version }}"
+      echo "provider: ${{ steps.version.outputs.dynamic_provider }}"
 ```
 
 ## Inputs
 
 <!-- markdownlint-disable MD013 -->
 
-| Output Variable     | Required | Description                                    |
-| ------------------- | -------- | ---------------------------------------------- |
-| path_prefix         | False    | Directory path to the repository/project files |
+| Input         | Required | Default | Description                                    |
+| ------------- | -------- | ------- | ---------------------------------------------- |
+| `path_prefix` | False    | `.`     | Directory path to the repository/project files |
 
 <!-- markdownlint-enable MD013 -->
 
@@ -34,11 +57,19 @@ An example workflow step using this action:
 
 <!-- markdownlint-disable MD013 -->
 
-| Output Variable        | Description                                                   |
-| ---------------------- | ------------------------------------------------------------- |
-| python_project_version | Current version of the Python Project                         |
-| source                 | Project metadata/description file [ pyproject.toml/setup.py ] |
-
-Note: python_project_version set to 'dynamic' when dynamic project versioning enabled
+| Output                   | Description                                                                                            |
+| ------------------------ | ------------------------------------------------------------------------------------------------------ |
+| `python_project_version` | Current version of the project, or the literal `dynamic` when a dynamic versioning provider is in use. |
+| `source`                 | Path to the file that supplied the version (`pyproject.toml`, `setup.cfg`, or `setup.py`).             |
+| `dynamic_version`        | `true` when the project uses dynamic versioning, `false` otherwise.                                    |
+| `dynamic_provider`       | Identifier of the dynamic versioning provider (see list above). Empty when `dynamic_version` is false. |
 
 <!-- markdownlint-enable MD013 -->
+
+## Implementation
+
+The action delegates version detection to `scripts/extract_version.py`,
+a small Python helper bundled with the action. The helper uses the
+standard library's `tomllib` (Python 3.11+) / `tomli` (3.10 fallback)
+for `pyproject.toml` and `configparser` for `setup.cfg`, and falls back
+to regex for `setup.py`. The full unit-test suite lives under `tests/`.

--- a/action.yaml
+++ b/action.yaml
@@ -5,7 +5,9 @@
 # python-project-version-action
 name: '🐍 Python Project Version'
 description: 'Returns the version of a Python Project'
-# Supports both pyproject.toml and setup.py project descriptions
+# Supports pyproject.toml, setup.cfg, and setup.py project descriptions,
+# including PBR / setuptools-scm / versioneer / setuptools-dynamic
+# dynamic-versioning providers.
 
 inputs:
   # Optional
@@ -16,12 +18,26 @@ inputs:
 
 outputs:
   python_project_version:
-    description: 'The current version declared for a Python project'
-    value: "${{ steps.set.outputs.python_project_version }}"
+    description: >-
+      The current version declared for a Python project, or the literal
+      string "dynamic" when the project uses a dynamic versioning provider.
+    value: "${{ steps.extract.outputs.python_project_version }}"
   source:
-    # yamllint disable-line rule:line-length
-    description: 'File used to source project metadata [pyproject.toml|setup.py]'
-    value: "${{ steps.set.outputs.python_project_version }}"
+    description: >-
+      Path to the file the version (or dynamic flag) was sourced from
+      (pyproject.toml | setup.cfg | setup.py).
+    value: "${{ steps.extract.outputs.source }}"
+  dynamic_version:
+    description: >-
+      "true" when the project uses a dynamic versioning provider (PBR,
+      setuptools-scm, versioneer, setuptools-dynamic). "false" otherwise.
+    value: "${{ steps.extract.outputs.dynamic_version }}"
+  dynamic_provider:
+    description: >-
+      When dynamic_version is true, identifies the provider:
+      pbr | setuptools-scm | versioneer | setuptools-dynamic |
+      hatch-vcs | pyproject-dynamic | runtime-attr. Empty when static.
+    value: "${{ steps.extract.outputs.dynamic_provider }}"
 
 runs:
   using: 'composite'
@@ -33,84 +49,18 @@ runs:
 
         # Verify path_prefix a valid directory path
         if [ ! -d "${{ inputs.path_prefix }}" ]; then
-          echo 'Error: invalid path/prefix to project directory ❌'; exit 1
+          echo 'Error: invalid path/prefix to project directory ❌'
+          exit 1
         fi
 
-    # yamllint disable-line rule:line-length
-    - uses: lfreleng-actions/path-check-action@9606e61c870025bc956e63156d1d55c5df54426c # v0.2.0
-      id: 'setup-py'
-      with:
-        path: "${{ inputs.path_prefix }}/setup.py"
-
-    - name: 'Use project version from setup.py'
-      id: 'setup-py-version'
-      if: steps.setup-py.outputs.type == 'file'
-      # yamllint disable-line rule:line-length
-      uses: lfreleng-actions/file-grep-regex-action@ba13750798b15e6acf23f3342a280ffc8148b950 # v0.1.4
-      with:
-        flags: '-oP -m1'
-        # https://regex101.com/r/QKYHId/1
-        regex: '(?<=version=")([^"]*)'
-        filename: "${{ inputs.path_prefix }}/setup.py"
-
-    # yamllint disable-line rule:line-length
-    - uses: lfreleng-actions/path-check-action@9606e61c870025bc956e63156d1d55c5df54426c # v0.2.0
-      id: 'pyproject-toml'
-      with:
-        path: "${{ inputs.path_prefix }}/pyproject.toml"
-
-    - name: 'Error: Python project metadata NOT found'
-      if: steps.pyproject-toml.outputs.type == 'invalid' &&
-        steps.setup-py.outputs.type == 'invalid'
+    - name: 'Extract Python project version'
+      id: extract
       shell: bash
+      env:
+        INPUT_PATH_PREFIX: ${{ inputs.path_prefix }}
       run: |
-        # Error: Python project metadata NOT found
-        echo 'Error: neither pyproject.toml nor setup.py were found ❌'
-        exit 1
-
-    - name: 'Determine versioning type [static|dynamic]'
-      if: steps.pyproject-toml.outputs.type == 'file'
-      id: versioning
-      # yamllint disable-line rule:line-length
-      uses: lfreleng-actions/python-dynamic-version-action@a64458c0978feeb833ee5fcc10af7ff99122a31a # v0.1.7
-      with:
-        path_prefix: "${{ inputs.path_prefix }}"
-
-    - name: 'Use project version from pyproject.toml'
-      id: 'pyproject-toml-version'
-      # yamllint disable-line rule:line-length
-      if: steps.pyproject-toml.outputs.type == 'file' && steps.versioning.outputs.dynamic_version != 'true'
-      # yamllint disable-line rule:line-length
-      uses: lfreleng-actions/file-grep-regex-action@ba13750798b15e6acf23f3342a280ffc8148b950 # v0.1.4
-      with:
-        flags: '-oP -m1'
-        # https://regex101.com/r/MWmRge/1
-        regex: '(?<=^version = ")([^"]*)'
-        filename: "${{ inputs.path_prefix }}/pyproject.toml"
-
-    - name: 'Return extracted values'
-      id: set
-      shell: bash
-      # yamllint disable rule:line-length
-      run: |
-        # Return extracted values
-
-        if [ "${{ steps.pyproject-toml.outputs.type }}" = 'file' ]; then
-          source='pyproject.toml'
-          version="${{ steps.pyproject-toml-version.outputs.extracted_string}}"
-        elif [ "${{ steps.setup-py.outputs.type }}" = 'file' ]; then
-          source='setup.py'
-          version="${{ steps.setup-py-version.outputs.extracted_string}}"
-        fi
-        if [ "${{ steps.versioning.outputs.dynamic_version }}" = 'true' ]; then
-          version='dynamic'
-        fi
-
-        # Validate and output captured value
-        if [ -z "$version" ]; then
-          echo 'Project version extraction failed ❌'; exit 1
-        else
-          echo "Python project version: $version [$source] ✅"
-          echo "python_project_version=$version" >> "$GITHUB_ENV"
-          echo "python_project_version=$version" >> "$GITHUB_OUTPUT"
-        fi
+        # Delegate detection to the bundled Python helper, which handles
+        # pyproject.toml (PEP 621 / poetry), setup.cfg (declarative
+        # setuptools / PBR / attr:/file: indirection), and setup.py
+        # (regex with single- and double-quoted forms) uniformly.
+        python3 "$GITHUB_ACTION_PATH/scripts/extract_version.py"

--- a/scripts/extract_version.py
+++ b/scripts/extract_version.py
@@ -23,8 +23,9 @@ when running inside a GitHub Action and to stdout when running stand-alone:
 * ``source`` -- the file path the version (or dynamic flag) was derived
   from.
 * ``dynamic_version`` -- ``true`` when a dynamic provider was detected.
-* ``dynamic_provider`` -- ``pbr`` | ``setuptools-scm`` | ``versioneer`` |
-  ``setuptools-dynamic`` | ``runtime-attr`` | ``""`` (static).
+* ``dynamic_provider`` -- ``pbr`` | ``setuptools-scm`` | ``hatch-vcs`` |
+  ``versioneer`` | ``setuptools-dynamic`` | ``pyproject-dynamic`` |
+  ``runtime-attr`` | ``""`` (static).
 """
 
 from __future__ import annotations
@@ -53,6 +54,15 @@ _SCM_IN_SETUP_REQUIRES = re.compile(
 )
 _PBR_KWARG = re.compile(r"\bpbr\s*=\s*True\b", re.IGNORECASE)
 
+# Match ``version=`` assignments referencing a non-literal identifier such
+# as ``__version__``, ``pkg.__version__``, ``get_version`` or
+# ``read_version`` (with or without a trailing call). Anchoring on
+# ``version\s*=`` avoids false positives from unrelated occurrences of
+# the ``__version__`` substring in imports, docstrings, or comments.
+_RUNTIME_ATTR_ASSIGN = re.compile(
+    r"\bversion\s*=\s*(?:[\w.]*__version__|get_version|read_version)\b",
+)
+
 
 def detect_dynamic_provider_setup_py(text: str) -> str:
     """Return the dynamic-versioning provider implied by setup.py.
@@ -65,11 +75,7 @@ def detect_dynamic_provider_setup_py(text: str) -> str:
         return "setuptools-scm"
     if "versioneer.get_version" in text or "versioneer.get_cmdclass" in text:
         return "versioneer"
-    if (
-        "__version__" in text
-        or "version=get_version" in text
-        or "version=read_version" in text
-    ):
+    if _RUNTIME_ATTR_ASSIGN.search(text):
         return "runtime-attr"
     return ""
 
@@ -109,10 +115,11 @@ def _read_setup_cfg(path: Path) -> configparser.ConfigParser:
         strict=False,
         empty_lines_in_values=False,
     )
-    # configparser is case-insensitive by default on Windows-style files;
-    # keep the explicit lowercase mapping behaviour here so that both
-    # author_email and author-email become ``author-email`` (we then look
-    # up both spellings on read).
+    # Preserve option keys exactly as written in the file. By default,
+    # ``configparser`` lowercases keys via ``optionxform``; assigning
+    # ``str`` disables that transform. ``_get_cfg`` then probes both
+    # ``author_email`` and ``author-email`` spellings explicitly when
+    # reading values.
     cfg.optionxform = str  # type: ignore[assignment,method-assign]
     cfg.read(path, encoding="utf-8")
     return cfg
@@ -203,10 +210,13 @@ def extract_from_setup_py(path: Path) -> tuple[str, str, str]:
     if provider in {"pbr", "setuptools-scm", "versioneer"}:
         return "dynamic", provider, ""
 
-    # version='...' / version="..." / version = '...' etc.
-    match = re.search(r"""version\s*=\s*['"]([^'"]+)['"]""", text)
+    # version='...' / version="..." / version = '...' etc. A static
+    # quoted literal wins outright: clear ``provider`` so a stray
+    # ``__version__`` reference elsewhere in the file cannot leak a
+    # spurious ``runtime-attr`` value to downstream consumers.
+    match = re.search(r"""version\s*=\s*['\"]([^'\"]+)['\"]""", text)
     if match:
-        return match.group(1), provider, ""
+        return match.group(1), "", ""
 
     # Fall back to runtime-attr style (version=__version__ etc.) which we
     # cannot resolve statically.

--- a/scripts/extract_version.py
+++ b/scripts/extract_version.py
@@ -1,0 +1,316 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+"""Extract the version of a Python project.
+
+Supported sources, in priority order:
+
+1. ``pyproject.toml`` (PEP 621 ``[project].version`` or
+   ``[tool.poetry].version``; ``dynamic = ["version"]`` is recognised).
+2. ``setup.cfg`` (``[metadata] version`` field; ``attr:``/``file:``
+   indirection is recognised as dynamic).
+3. ``setup.py`` (regex-based extraction, single- and double-quoted forms).
+
+When the project uses a dynamic versioning provider (PBR,
+setuptools-scm, versioneer, setuptools-dynamic) the script emits
+``version=dynamic`` and surfaces the provider via ``dynamic_provider``.
+
+Outputs (one per line, ``key=value``) are written to ``GITHUB_OUTPUT``
+when running inside a GitHub Action and to stdout when running stand-alone:
+
+* ``python_project_version`` -- the resolved version, or the literal
+  ``dynamic`` for dynamic-versioned projects.
+* ``source`` -- the file path the version (or dynamic flag) was derived
+  from.
+* ``dynamic_version`` -- ``true`` when a dynamic provider was detected.
+* ``dynamic_provider`` -- ``pbr`` | ``setuptools-scm`` | ``versioneer`` |
+  ``setuptools-dynamic`` | ``runtime-attr`` | ``""`` (static).
+"""
+
+from __future__ import annotations
+
+import argparse
+import configparser
+import os
+import re
+import sys
+from pathlib import Path
+
+try:  # pragma: no cover - exercised on Python >= 3.11
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python 3.10
+    import tomli as tomllib  # type: ignore[import-not-found,no-redef]
+
+
+# Regex patterns shared by setup.py and setup.cfg analysis.
+_PBR_IN_SETUP_REQUIRES = re.compile(
+    r"setup_requires\s*=\s*\[[^\]]*['\"]pbr",
+    re.IGNORECASE,
+)
+_SCM_IN_SETUP_REQUIRES = re.compile(
+    r"setup_requires\s*=\s*\[[^\]]*['\"]setuptools[_-]scm",
+    re.IGNORECASE,
+)
+_PBR_KWARG = re.compile(r"\bpbr\s*=\s*True\b", re.IGNORECASE)
+
+
+def detect_dynamic_provider_setup_py(text: str) -> str:
+    """Return the dynamic-versioning provider implied by setup.py.
+
+    Returns the empty string when no dynamic-versioning marker is found.
+    """
+    if _PBR_KWARG.search(text) or _PBR_IN_SETUP_REQUIRES.search(text):
+        return "pbr"
+    if "use_scm_version" in text or _SCM_IN_SETUP_REQUIRES.search(text):
+        return "setuptools-scm"
+    if "versioneer.get_version" in text or "versioneer.get_cmdclass" in text:
+        return "versioneer"
+    if (
+        "__version__" in text
+        or "version=get_version" in text
+        or "version=read_version" in text
+    ):
+        return "runtime-attr"
+    return ""
+
+
+def detect_dynamic_provider_setup_cfg(cfg: configparser.ConfigParser) -> str:
+    """Return the dynamic-versioning provider implied by setup.cfg.
+
+    Returns the empty string when no dynamic-versioning marker is found.
+    """
+    if cfg.has_section("pbr"):
+        return "pbr"
+
+    if cfg.has_option("metadata", "version"):
+        version = cfg.get("metadata", "version").strip()
+        if version.startswith("attr:") or version.startswith("file:"):
+            return "setuptools-dynamic"
+
+    if cfg.has_option("options", "setup_requires"):
+        for line in cfg.get("options", "setup_requires").splitlines():
+            line = line.strip().lower()
+            if not line:
+                continue
+            if "pbr" in line:
+                return "pbr"
+            if "setuptools_scm" in line or "setuptools-scm" in line:
+                return "setuptools-scm"
+            if "versioneer" in line:
+                return "versioneer"
+
+    return ""
+
+
+def _read_setup_cfg(path: Path) -> configparser.ConfigParser:
+    """Parse setup.cfg, tolerating duplicate keys (older PBR style)."""
+    cfg = configparser.ConfigParser(
+        interpolation=None,
+        strict=False,
+        empty_lines_in_values=False,
+    )
+    # configparser is case-insensitive by default on Windows-style files;
+    # keep the explicit lowercase mapping behaviour here so that both
+    # author_email and author-email become ``author-email`` (we then look
+    # up both spellings on read).
+    cfg.optionxform = str  # type: ignore[assignment,method-assign]
+    cfg.read(path, encoding="utf-8")
+    return cfg
+
+
+def _get_cfg(cfg: configparser.ConfigParser, section: str, key: str) -> str:
+    """Look up a value in setup.cfg supporting both hyphen and underscore
+    spellings (older setuptools / PBR conventions).
+    """
+    if not cfg.has_section(section):
+        return ""
+    for candidate in (key, key.replace("_", "-"), key.replace("-", "_")):
+        if cfg.has_option(section, candidate):
+            return cfg.get(section, candidate).strip()
+    return ""
+
+
+def extract_from_pyproject(path: Path) -> tuple[str, str, str]:
+    """Extract ``(version, dynamic_provider, error_message)`` from
+    pyproject.toml. ``version`` is the resolved value, the literal
+    ``dynamic`` when the project declares dynamic versioning, or empty
+    when extraction failed (in which case ``error_message`` is set).
+    """
+    try:
+        with path.open("rb") as handle:
+            data = tomllib.load(handle)
+    except Exception as exc:  # pragma: no cover - exercised on bad TOML
+        return "", "", f"failed to parse pyproject.toml: {exc}"
+
+    project = data.get("project") or {}
+    dynamic_fields = project.get("dynamic") or []
+    if "version" in dynamic_fields:
+        # Detect provider from build-system requires.
+        requires = data.get("build-system", {}).get("requires", []) or []
+        joined = " ".join(requires).lower()
+        if "setuptools_scm" in joined or "setuptools-scm" in joined:
+            return "dynamic", "setuptools-scm", ""
+        if "hatch-vcs" in joined:
+            return "dynamic", "hatch-vcs", ""
+        if "pbr" in joined:
+            return "dynamic", "pbr", ""
+        return "dynamic", "pyproject-dynamic", ""
+
+    version = project.get("version") or ""
+    if not version:
+        # Poetry layout: [tool.poetry].version
+        tool = data.get("tool") or {}
+        poetry = tool.get("poetry") or {}
+        version = poetry.get("version") or ""
+
+    return version, "", ""
+
+
+def extract_from_setup_cfg(
+    path: Path, setup_py_text: str | None
+) -> tuple[str, str, str]:
+    """Extract ``(version, dynamic_provider, error_message)`` from
+    setup.cfg. Optionally cross-references ``setup_py_text`` to detect the
+    canonical PBR layout (declarative setup.cfg + minimal setup.py shim).
+    """
+    try:
+        cfg = _read_setup_cfg(path)
+    except configparser.Error as exc:
+        return "", "", f"failed to parse setup.cfg: {exc}"
+
+    provider = detect_dynamic_provider_setup_cfg(cfg)
+    if not provider and setup_py_text:
+        provider = detect_dynamic_provider_setup_py(setup_py_text)
+
+    if provider:
+        return "dynamic", provider, ""
+
+    version = _get_cfg(cfg, "metadata", "version")
+    return version, "", ""
+
+
+def extract_from_setup_py(path: Path) -> tuple[str, str, str]:
+    """Extract ``(version, dynamic_provider, error_message)`` from setup.py
+    using regex; recognises single- and double-quoted forms as well as
+    common dynamic providers.
+    """
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return "", "", f"failed to read setup.py: {exc}"
+
+    provider = detect_dynamic_provider_setup_py(text)
+    if provider in {"pbr", "setuptools-scm", "versioneer"}:
+        return "dynamic", provider, ""
+
+    # version='...' / version="..." / version = '...' etc.
+    match = re.search(r"""version\s*=\s*['"]([^'"]+)['"]""", text)
+    if match:
+        return match.group(1), provider, ""
+
+    # Fall back to runtime-attr style (version=__version__ etc.) which we
+    # cannot resolve statically.
+    if provider == "runtime-attr":
+        return "dynamic", provider, ""
+
+    return "", "", ""
+
+
+def emit(outputs: dict[str, str]) -> None:
+    """Write outputs as ``key=value`` lines to ``$GITHUB_OUTPUT`` (or
+    stdout when the variable is unset).
+    """
+    target = os.environ.get("GITHUB_OUTPUT")
+    handle = open(target, "a", encoding="utf-8") if target else sys.stdout
+    try:
+        for key, value in outputs.items():
+            print(f"{key}={value}", file=handle)
+    finally:
+        if target:
+            handle.close()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--path-prefix",
+        default=os.environ.get("INPUT_PATH_PREFIX", "."),
+        help="Directory containing the project metadata files.",
+    )
+    args = parser.parse_args(argv)
+
+    prefix = Path(args.path_prefix)
+    if not prefix.is_dir():
+        print(
+            f"Error: invalid path/prefix to project directory: {prefix}",
+            file=sys.stderr,
+        )
+        return 1
+
+    pyproject = prefix / "pyproject.toml"
+    setup_cfg = prefix / "setup.cfg"
+    setup_py = prefix / "setup.py"
+
+    setup_py_text: str | None = None
+    if setup_py.is_file():
+        try:
+            setup_py_text = setup_py.read_text(encoding="utf-8")
+        except OSError:
+            setup_py_text = None
+
+    version = ""
+    provider = ""
+    source = ""
+    error = ""
+
+    if pyproject.is_file():
+        version, provider, error = extract_from_pyproject(pyproject)
+        source = str(pyproject)
+
+    if not version and setup_cfg.is_file():
+        version, provider, error = extract_from_setup_cfg(setup_cfg, setup_py_text)
+        source = str(setup_cfg)
+
+    if not version and setup_py.is_file():
+        version, provider, error = extract_from_setup_py(setup_py)
+        source = str(setup_py)
+
+    if error:
+        print(f"Error: {error}", file=sys.stderr)
+        return 1
+
+    if not version:
+        if not (pyproject.is_file() or setup_cfg.is_file() or setup_py.is_file()):
+            print(
+                "Error: no Python project metadata found "
+                "(searched pyproject.toml, setup.cfg, setup.py)",
+                file=sys.stderr,
+            )
+            return 1
+        print(
+            "Error: Python project version extraction failed; "
+            "no version field detected in project metadata",
+            file=sys.stderr,
+        )
+        return 1
+
+    dynamic_flag = "true" if version == "dynamic" else "false"
+
+    emit(
+        {
+            "python_project_version": version,
+            "source": source,
+            "dynamic_version": dynamic_flag,
+            "dynamic_provider": provider,
+        }
+    )
+
+    label = f"Python project version: {version} [{source}]"
+    if provider:
+        label += f" (dynamic_provider={provider})"
+    print(f"{label} ✅")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_extract_version.py
+++ b/tests/test_extract_version.py
@@ -1,0 +1,417 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+"""Comprehensive fixture-based tests for ``extract_version.py``.
+
+Each test materialises a small fixture project in a temp directory, runs
+the extractor, and asserts on the captured ``GITHUB_OUTPUT`` lines. The
+fixtures are inlined here rather than living on disk so the test surface
+is fully self-contained and obvious at review time.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parent.parent / "scripts" / "extract_version.py"
+
+
+def _run(tmp_path: Path, files: dict[str, str]) -> tuple[int, dict[str, str], str, str]:
+    """Materialise ``files`` under ``tmp_path`` and run the extractor.
+
+    Returns ``(returncode, outputs, stdout, stderr)``. ``outputs`` is the
+    parsed ``GITHUB_OUTPUT`` content (``key=value`` lines).
+    """
+    for name, content in files.items():
+        target = tmp_path / name
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(content, encoding="utf-8")
+
+    github_output = tmp_path / ".github_output"
+    github_output.write_text("", encoding="utf-8")
+
+    env = os.environ.copy()
+    env["GITHUB_OUTPUT"] = str(github_output)
+    env["INPUT_PATH_PREFIX"] = str(tmp_path)
+
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPT)],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+
+    outputs: dict[str, str] = {}
+    for line in github_output.read_text(encoding="utf-8").splitlines():
+        if "=" in line:
+            key, value = line.split("=", 1)
+            outputs[key] = value
+
+    return proc.returncode, outputs, proc.stdout, proc.stderr
+
+
+# -- pyproject.toml -----------------------------------------------------
+
+
+def test_pyproject_static_version(tmp_path: Path) -> None:
+    """A modern PEP 621 pyproject.toml with a literal version."""
+    rc, out, _, _ = _run(
+        tmp_path,
+        {
+            "pyproject.toml": ('[project]\nname = "modern-pkg"\nversion = "1.2.3"\n'),
+        },
+    )
+    assert rc == 0
+    assert out["python_project_version"] == "1.2.3"
+    assert out["dynamic_version"] == "false"
+    assert out["dynamic_provider"] == ""
+    assert out["source"].endswith("pyproject.toml")
+
+
+def test_pyproject_dynamic_version_with_setuptools_scm(tmp_path: Path) -> None:
+    """pyproject.toml declaring dynamic=['version'] with setuptools-scm."""
+    rc, out, _, _ = _run(
+        tmp_path,
+        {
+            "pyproject.toml": (
+                "[build-system]\n"
+                'requires = ["setuptools>=61", "setuptools_scm>=6.0"]\n'
+                "\n"
+                "[project]\n"
+                'name = "scm-pkg"\n'
+                'dynamic = ["version"]\n'
+            ),
+        },
+    )
+    assert rc == 0
+    assert out["python_project_version"] == "dynamic"
+    assert out["dynamic_version"] == "true"
+    assert out["dynamic_provider"] == "setuptools-scm"
+
+
+def test_pyproject_dynamic_version_with_hatch_vcs(tmp_path: Path) -> None:
+    """pyproject.toml declaring dynamic=['version'] with hatch-vcs."""
+    rc, out, _, _ = _run(
+        tmp_path,
+        {
+            "pyproject.toml": (
+                "[build-system]\n"
+                'requires = ["hatchling", "hatch-vcs"]\n'
+                "\n"
+                "[project]\n"
+                'name = "hatch-pkg"\n'
+                'dynamic = ["version"]\n'
+            ),
+        },
+    )
+    assert rc == 0
+    assert out["python_project_version"] == "dynamic"
+    assert out["dynamic_provider"] == "hatch-vcs"
+
+
+def test_pyproject_poetry(tmp_path: Path) -> None:
+    """Poetry-style pyproject.toml without a [project] table."""
+    rc, out, _, _ = _run(
+        tmp_path,
+        {
+            "pyproject.toml": (
+                '[tool.poetry]\nname = "poetry-pkg"\nversion = "0.5.0"\n'
+            ),
+        },
+    )
+    assert rc == 0
+    assert out["python_project_version"] == "0.5.0"
+    assert out["dynamic_version"] == "false"
+
+
+# -- setup.cfg ----------------------------------------------------------
+
+
+def test_setup_cfg_static(tmp_path: Path) -> None:
+    """Declarative setuptools setup.cfg with literal version."""
+    rc, out, _, _ = _run(
+        tmp_path,
+        {
+            "setup.cfg": ("[metadata]\nname = cfg-pkg\nversion = 0.9.0\n"),
+        },
+    )
+    assert rc == 0
+    assert out["python_project_version"] == "0.9.0"
+    assert out["source"].endswith("setup.cfg")
+    assert out["dynamic_version"] == "false"
+
+
+def test_setup_cfg_attr_indirection_is_dynamic(tmp_path: Path) -> None:
+    """``attr:`` version indirection must report dynamic."""
+    rc, out, _, _ = _run(
+        tmp_path,
+        {
+            "setup.cfg": (
+                "[metadata]\nname = attr-pkg\nversion = attr: attr_pkg.__version__\n"
+            ),
+        },
+    )
+    assert rc == 0
+    assert out["python_project_version"] == "dynamic"
+    assert out["dynamic_provider"] == "setuptools-dynamic"
+
+
+def test_setup_cfg_file_indirection_is_dynamic(tmp_path: Path) -> None:
+    """``file:`` version indirection must report dynamic."""
+    rc, out, _, _ = _run(
+        tmp_path,
+        {
+            "setup.cfg": ("[metadata]\nname = file-pkg\nversion = file: VERSION\n"),
+        },
+    )
+    assert rc == 0
+    assert out["python_project_version"] == "dynamic"
+    assert out["dynamic_provider"] == "setuptools-dynamic"
+
+
+def test_pbr_setup_cfg_plus_setup_py_shim(tmp_path: Path) -> None:
+    """Canonical OpenStack/PBR layout: declarative setup.cfg + minimal
+    setup.py shim carrying the pbr=True marker. setup.cfg alone provides
+    no version, so the action must read setup.py to detect PBR and emit
+    ``dynamic``.
+    """
+    rc, out, _, _ = _run(
+        tmp_path,
+        {
+            "setup.cfg": (
+                "[metadata]\n"
+                "name = pbr-pkg\n"
+                "author = Test\n"
+                "author-email = test@example.org\n"
+            ),
+            "setup.py": (
+                "from setuptools import setup\n"
+                "setup(setup_requires=['pbr'], pbr=True)\n"
+            ),
+        },
+    )
+    assert rc == 0
+    assert out["python_project_version"] == "dynamic"
+    assert out["dynamic_provider"] == "pbr"
+
+
+def test_setup_cfg_with_setup_requires_scm(tmp_path: Path) -> None:
+    """setup.cfg declaring setuptools_scm in [options].setup_requires."""
+    rc, out, _, _ = _run(
+        tmp_path,
+        {
+            "setup.cfg": (
+                "[metadata]\n"
+                "name = scm-cfg-pkg\n"
+                "\n"
+                "[options]\n"
+                "setup_requires =\n"
+                "    setuptools_scm\n"
+            ),
+        },
+    )
+    assert rc == 0
+    assert out["python_project_version"] == "dynamic"
+    assert out["dynamic_provider"] == "setuptools-scm"
+
+
+def test_setup_cfg_hyphenated_keys(tmp_path: Path) -> None:
+    """Older setup.cfg with hyphenated keys must still extract version."""
+    rc, out, _, _ = _run(
+        tmp_path,
+        {
+            "setup.cfg": (
+                "[metadata]\nname = hyphen-pkg\nauthor-email = a@b\nversion = 3.4.5\n"
+            ),
+        },
+    )
+    assert rc == 0
+    assert out["python_project_version"] == "3.4.5"
+
+
+# -- setup.py -----------------------------------------------------------
+
+
+def test_setup_py_double_quoted(tmp_path: Path) -> None:
+    """Plain setup.py with double-quoted version string."""
+    rc, out, _, _ = _run(
+        tmp_path,
+        {
+            "setup.py": (
+                "from setuptools import setup\n"
+                'setup(name="quoted-pkg", version="2.0.0")\n'
+            ),
+        },
+    )
+    assert rc == 0
+    assert out["python_project_version"] == "2.0.0"
+    assert out["source"].endswith("setup.py")
+
+
+def test_setup_py_single_quoted(tmp_path: Path) -> None:
+    """Plain setup.py with single-quoted version string."""
+    rc, out, _, _ = _run(
+        tmp_path,
+        {
+            "setup.py": (
+                "from setuptools import setup\n"
+                "setup(name='single-pkg', version='1.0.0')\n"
+            ),
+        },
+    )
+    assert rc == 0
+    assert out["python_project_version"] == "1.0.0"
+
+
+def test_setup_py_pbr_only(tmp_path: Path) -> None:
+    """setup.py-only PBR project (no setup.cfg)."""
+    rc, out, _, _ = _run(
+        tmp_path,
+        {
+            "setup.py": (
+                "from setuptools import setup\n"
+                "setup(name='pbr-only', setup_requires=['pbr>=2.0'], pbr=True)\n"
+            ),
+        },
+    )
+    assert rc == 0
+    assert out["python_project_version"] == "dynamic"
+    assert out["dynamic_provider"] == "pbr"
+
+
+def test_setup_py_use_scm_version(tmp_path: Path) -> None:
+    """setup.py-only project using setuptools-scm."""
+    rc, out, _, _ = _run(
+        tmp_path,
+        {
+            "setup.py": (
+                "from setuptools import setup\n"
+                "setup(name='scm-only', use_scm_version=True)\n"
+            ),
+        },
+    )
+    assert rc == 0
+    assert out["python_project_version"] == "dynamic"
+    assert out["dynamic_provider"] == "setuptools-scm"
+
+
+def test_setup_py_versioneer(tmp_path: Path) -> None:
+    """setup.py-only project using versioneer."""
+    rc, out, _, _ = _run(
+        tmp_path,
+        {
+            "setup.py": (
+                "from setuptools import setup\n"
+                "import versioneer\n"
+                "setup(name='vsn-pkg',\n"
+                "      version=versioneer.get_version(),\n"
+                "      cmdclass=versioneer.get_cmdclass())\n"
+            ),
+        },
+    )
+    assert rc == 0
+    assert out["python_project_version"] == "dynamic"
+    assert out["dynamic_provider"] == "versioneer"
+
+
+def test_setup_py_runtime_attr(tmp_path: Path) -> None:
+    """setup.py-only project referencing __version__ at runtime."""
+    rc, out, _, _ = _run(
+        tmp_path,
+        {
+            "setup.py": (
+                "from pkg import __version__\n"
+                "from setuptools import setup\n"
+                "setup(name='rtattr-pkg', version=__version__)\n"
+            ),
+        },
+    )
+    assert rc == 0
+    assert out["python_project_version"] == "dynamic"
+    assert out["dynamic_provider"] == "runtime-attr"
+
+
+# -- precedence ---------------------------------------------------------
+
+
+def test_pyproject_takes_precedence_over_setup_cfg(tmp_path: Path) -> None:
+    """pyproject.toml wins when both files declare a static version."""
+    rc, out, _, _ = _run(
+        tmp_path,
+        {
+            "pyproject.toml": ('[project]\nname = "p"\nversion = "9.9.9"\n'),
+            "setup.cfg": ("[metadata]\nname = p\nversion = 0.0.0\n"),
+        },
+    )
+    assert rc == 0
+    assert out["python_project_version"] == "9.9.9"
+    assert out["source"].endswith("pyproject.toml")
+
+
+# -- error paths --------------------------------------------------------
+
+
+def test_missing_metadata_files(tmp_path: Path) -> None:
+    """No pyproject.toml/setup.cfg/setup.py => error."""
+    rc, _, _, stderr = _run(tmp_path, {})
+    assert rc != 0
+    assert "no Python project metadata" in stderr
+
+
+def test_metadata_present_but_no_version(tmp_path: Path) -> None:
+    """A file exists but contains no version field nor dynamic markers."""
+    rc, _, _, stderr = _run(
+        tmp_path,
+        {
+            "setup.cfg": ("[metadata]\nname = no-version\n"),
+        },
+    )
+    assert rc != 0
+    assert "version extraction failed" in stderr
+
+
+def test_invalid_path_prefix(tmp_path: Path) -> None:
+    """A non-existent path_prefix must fail cleanly."""
+    env = os.environ.copy()
+    env["INPUT_PATH_PREFIX"] = str(tmp_path / "does-not-exist")
+    env["GITHUB_OUTPUT"] = str(tmp_path / "out")
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPT)],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+    assert proc.returncode != 0
+    assert "invalid path/prefix" in proc.stderr
+
+
+# -- helper-level coverage ---------------------------------------------
+
+
+def test_helper_detect_dynamic_provider_setup_py() -> None:
+    """Direct unit-test of the setup.py provider detector."""
+    sys.path.insert(0, str(SCRIPT.parent))
+    try:
+        from extract_version import detect_dynamic_provider_setup_py as detect
+    finally:
+        sys.path.pop(0)
+
+    assert detect("setup(pbr=True)") == "pbr"
+    assert detect("setup_requires=['pbr']") == "pbr"
+    assert detect("setup_requires=['setuptools_scm>=6.0']") == "setuptools-scm"
+    assert detect("setup_requires = [ 'setuptools-scm' ]") == "setuptools-scm"
+    assert detect("setup(use_scm_version=True)") == "setuptools-scm"
+    assert detect("versioneer.get_version()") == "versioneer"
+    assert detect("setup(version='1.0')") == ""
+    assert detect("setup(version=__version__)") == "runtime-attr"
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary

Rewrite the action around a single Python helper script (`scripts/extract_version.py`), replacing the chained `file-grep-regex` / `file-sed-regex` / nested-action composition. The new implementation closes several long-standing gaps and bugs:

- **`source` output bug** — bound to the version string rather than the source-file path (copy-paste bug in the previous `action.yaml`).
- **`setup.cfg` had no support** — any project using only `setup.cfg` (declarative setuptools / PBR / OpenStack convention) returned an empty version and failed the action.
- **No PBR / setuptools-scm / versioneer detection** — the canonical OpenStack layout (declarative `setup.cfg` paired with a minimal `setup.py` shim carrying `pbr=True`) was reported as static; downstream tag-verify steps then failed with "version string was empty".
- **`setup.py` regex fragility** — required double-quoted version strings; single quotes and computed assignments were silently mis-extracted.

This is **Phase 2 of 4** in a coordinated series across the Python actions portfolio; Phase 1 is https://github.com/lfreleng-actions/build-metadata-action/pull/70.

## Changes

### `scripts/extract_version.py` (new)

Self-contained Python helper that handles all three metadata files using the standard library:

- **`pyproject.toml`** via `tomllib` (3.11+) / `tomli` (3.10 fallback): PEP 621 `[project].version`, `[tool.poetry].version`, and `dynamic = ["version"]` with build-system requires inspection to attribute the provider.
- **`setup.cfg`** via `configparser`: `[metadata] version` with hyphen/underscore key alias normalisation (`author-email`/`author_email`, `python-requires`/`python_requires`); `attr:` / `file:` indirection recognised as dynamic.
- **`setup.py`** via regex: single- and double-quoted forms, with PBR / setuptools-scm / versioneer / runtime-attr provider detection.

Cross-references `setup.py` when `setup.cfg` is the primary metadata source (canonical PBR layout).

### `action.yaml`

Replaced multi-step composition with a single step that delegates to the helper script. New outputs:

| Output | Description |
|---|---|
| `python_project_version` | Unchanged contract; `dynamic` for dynamic-versioned projects. |
| `source` | **Fixed** — now returns the source-file path, not the version string. |
| `dynamic_version` | New boolean output. |
| `dynamic_provider` | New output: `pbr` \| `setuptools-scm` \| `versioneer` \| `setuptools-dynamic` \| `hatch-vcs` \| `pyproject-dynamic` \| `runtime-attr` \| empty. |

### `tests/test_extract_version.py` (new)

21 fixture-based scenarios materialised in `tmp_path`:

- pyproject.toml: static, setuptools-scm dynamic, hatch-vcs dynamic, poetry
- setup.cfg: static, `attr:` dynamic, `file:` dynamic, PBR (with setup.py shim), `setup_requires` setuptools-scm, hyphenated keys
- setup.py: single-quoted, double-quoted, PBR, use_scm_version, versioneer, runtime-attr
- Precedence: pyproject.toml wins over setup.cfg
- Error paths: missing files, file present but no version, invalid path_prefix
- Direct unit test of the setup.py provider detector

```
$ python3 -m pytest tests/test_extract_version.py -q
21 passed in 1.02s
```

### `.github/workflows/testing.yaml`

Two jobs:

- **`pytest`** — runs the new fixture-based test suite under Python 3.11.
- **`smoke`** — preserves the original end-to-end test against `lfreleng-actions/test-python-project`, exercising both the static (via the `variations/static-eol.toml` swap) and dynamic configurations, and additionally asserts that the `source` output is a path ending in `pyproject.toml` (regression guard for the fixed bug).

### `README.md`

Updated to document the new supported layouts, outputs, provider list, and implementation overview.

## Follow-up PRs

3. `python-dynamic-version-action` — extend to setup.cfg / setup.py and PBR/scm/versioneer (so callers that use it directly get the same coverage).
4. `python-build-action` — relax existence check for setup.cfg, inject `PBR_VERSION` for dynamic builds, bump build-metadata-action SHA pin.
