### PR TITLE
Fix: Env-mediate expressions in run blocks

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -106,20 +106,23 @@ jobs:
 
       - name: "Validate action output: ${{ github.repository }}"
         shell: bash
+        env:
+          PROJECT_VERSION: ${{ steps.test.outputs.python_project_version }}
+          VERSION_SOURCE: ${{ steps.test.outputs.source }}
+          DYN_IS_DYNAMIC: ${{ steps.test.outputs.dynamic_version }}
         run: |
           # Validate Action Output
-          if [ "${{ steps.test.outputs.python_project_version }}" \
-            = '0.0.1' ]; then
+          if [ "$PROJECT_VERSION" = '0.0.1' ]; then
             echo "Action returned the expected version ✅"
           else
             echo 'Unexpected return value for: python_project_version ❌'
-            echo "Returned: ${{ steps.test.outputs.python_project_version }}"
+            echo "Returned: $PROJECT_VERSION"
             echo 'Expected: 0.0.1'
             exit 1
           fi
           # Source output must be the actual file path now, not the
           # version string (regression test for the previous copy-paste bug).
-          source='${{ steps.test.outputs.source }}'
+          source="$VERSION_SOURCE"
           case "$source" in
             *pyproject.toml)
               echo "Source output is correct ($source) ✅"
@@ -131,7 +134,7 @@ jobs:
               ;;
           esac
           # Verify the new outputs are present and have expected values.
-          if [ "${{ steps.test.outputs.dynamic_version }}" != 'false' ]; then
+          if [ "$DYN_IS_DYNAMIC" != 'false' ]; then
             echo 'Expected dynamic_version=false for a static-version project ❌'
             exit 1
           fi
@@ -150,10 +153,14 @@ jobs:
 
       - name: "Validate dynamic version output"
         shell: bash
+        env:
+          DYN_VERSION: ${{ steps.test-dynamic.outputs.python_project_version }}
+          DYN_IS_DYNAMIC: ${{ steps.test-dynamic.outputs.dynamic_version }}
+          DYN_PROVIDER: ${{ steps.test-dynamic.outputs.dynamic_provider }}
         run: |
-          version='${{ steps.test-dynamic.outputs.python_project_version }}'
-          dynamic='${{ steps.test-dynamic.outputs.dynamic_version }}'
-          provider='${{ steps.test-dynamic.outputs.dynamic_provider }}'
+          version="$DYN_VERSION"
+          dynamic="$DYN_IS_DYNAMIC"
+          provider="$DYN_PROVIDER"
           if [ "$version" != 'dynamic' ] || [ "$dynamic" != 'true' ]; then
             echo 'Dynamic versioning not detected ❌'
             echo "version=$version dynamic_version=$dynamic"


### PR DESCRIPTION
## Why

The org-wide zizmor workflow (`lfreleng-actions/.github/workflows/zizmor.yaml`) was changed today:

```
2026-07-28T10:46  Feat: Surface all zizmor findings at any level
```

It runs `--persona auditor --min-severity informational` and now **fails a run on any finding at any level**. This repo carries 7 pre-existing `template-injection` findings, so *every* new PR here is blocked until they're cleared — currently #147.

## What

`.github/workflows/testing.yaml` expanded action outputs directly inside `run:` blocks. GitHub expands `${{ }}` *before* the shell sees the script, so a crafted value becomes shell source text rather than data. Routing through `env:` makes the value opaque to the shell parser.

Two steps were affected, both validating action outputs — the static-fixture check and the dynamic-version check:

```yaml
env:
  PROJECT_VERSION: ${{ steps.test.outputs.python_project_version }}
  VERSION_SOURCE: ${{ steps.test.outputs.source }}
  DYNAMIC_VERSION: ${{ steps.test.outputs.dynamic_version }}
run: |
  if [ "$PROJECT_VERSION" = '0.0.1' ]; then
```

The dynamic step's variables are prefixed `DYN_` so the version *string* (`DYN_VERSION`) and the dynamic-versioning *flag* (`DYN_IS_DYNAMIC`) stay distinguishable — they were `version` and `dynamic` locally, which would have collided as env names.

Same shape `python-workflows` uses (see its "Fix: Env-mediate expressions in run blocks"), and the `env:`-before-`run:` ordering already used elsewhere here.

## ⚠️ Why this was written by hand

zizmor offers an auto-fix for this audit. It is marked *unsafe*, and on inspection it is — it rewrites the expression in place and leaves it inside the **original single quotes**:

```diff
- source='${{ steps.test.outputs.source }}'
+ source='${STEPS_TEST_OUTPUTS_SOURCE}'
```

The shell does not expand `${...}` inside single quotes. The original was correct precisely *because* GitHub expanded the template before the shell ran; once the value moves to `env:`, expansion becomes the shell's job and the quoting has to change with it. Four of the seven fixes here would have been silently broken by the auto-fix.

## Validation

- `zizmor --persona auditor --min-severity informational` → **No findings to report**
- `pre-commit run --all-files` → all hooks pass, including `yamllint` and `actionlint`
- No behavioural change: the same values reach the same commands

Unblocks #147.
